### PR TITLE
[15기 김성훈] 모달창 이벤트 리스너 무한 생성 버그 픽스. 리뷰 부탁드립니다!

### DIFF
--- a/src/Components/PopUp/PopUp.js
+++ b/src/Components/PopUp/PopUp.js
@@ -9,7 +9,7 @@ const PopUp = ({ title, handleExit, children, bottom }) => {
   useEffect(() => {
     document.body.style.overflow = "hidden";
     backgroundRef.current.addEventListener("mousedown", handleClickOutside);
-  });
+  }, []);
 
   const handleClickOutside = event => {
     event.stopPropagation();


### PR DESCRIPTION
## 수정 사항 간략한 한줄 요약
- 공용으로 사용될 모달창 버그 수정
		 
## 수정 사항들 자세한 내용
- 기존에는 스테이트가 업데이트 되서 모달창이 새로 렌더링 될때마다 이벤트 리스너가 생성되었습니다.
- useEffect 두번째 인자로 `[]` 를 넘겨, 최초 한번만 생성하도록 수정.

## 기타 질문 및 특이 사항
```js
const PopUp = ({ title, handleExit, children, bottom }) => {
  const popUpRef = useRef();
  const backgroundRef = useRef();

  useEffect(() => {
    document.body.style.overflow = "hidden";
    backgroundRef.current.addEventListener("mousedown", handleClickOutside);
  }, []);

...
```
이렇게 구성이 되는데, 
`React Hook useEffect has a missing dependecy: 'handleClickOutside'. Either include it or remove the dependency array` 라고 경고가 나옵니다. 

제가 원하는 대로 작동하게 하려면, 빈 배열을 [] 넣어주는게 맞는데, 무시해도 되는 경고가 맞을까요?

## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
